### PR TITLE
Handle multiple connections from user

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 # Frontend
+NEXT_PUBLIC_USER_SERVICE_URL=http://localhost:8004
 NEXT_PUBLIC_MATCHING_SERVICE_URL=http://localhost:8002
 NEXT_PUBLIC_QUESTION_SERVICE_URL=http://localhost:8003
 # NEXT_PUBLIC_IMAGE_UPLOAD_KEY= <your-image-upload-key>

--- a/frontend/peerprep/.env.sample
+++ b/frontend/peerprep/.env.sample
@@ -1,3 +1,4 @@
+NEXT_PUBLIC_USER_SERVICE_URL=http://localhost:8004
 NEXT_PUBLIC_MATCHING_SERVICE_URL=http://localhost:8002
 NEXT_PUBLIC_QUESTION_SERVICE_URL=http://localhost:8003
 # NEXT_PUBLIC_IMAGE_UPLOAD_KEY=<insert your portive auth token here>

--- a/frontend/peerprep/components/matching/MatchErrorModal.tsx
+++ b/frontend/peerprep/components/matching/MatchErrorModal.tsx
@@ -1,0 +1,50 @@
+import { Spacer, Badge, Button } from "@nextui-org/react";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from "@nextui-org/modal";
+
+interface MatchErrorProps {
+  children: React.ReactNode;
+  onClose: () => void;
+  isOpen: boolean;
+}
+
+const MatchErrorModal: React.FC<MatchErrorProps> = ({
+  children,
+  onClose,
+  isOpen,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalContent>
+        <ModalHeader className="font-sans flex flex-col pt-8">
+          <p className="text-xl font-bold pb-2">Matchmaking Error!</p>
+        </ModalHeader>
+        <ModalBody>
+          <Badge variant="flat" color="warning">
+            {children}
+          </Badge>
+          <Spacer y={1} />
+          <p />
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color="secondary"
+            className="flex-1 mx-1"
+            radius="sm"
+            size="lg"
+            onClick={() => onClose()}
+          >
+            Continue
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default MatchErrorModal;

--- a/frontend/peerprep/components/matching/MatchUI.tsx
+++ b/frontend/peerprep/components/matching/MatchUI.tsx
@@ -11,6 +11,7 @@ import {
 import MatchFoundModal from "./MatchFoundModal";
 import MatchmakingModal from "./MatchmakingModal";
 import MatchTimeoutModal from "./MatchTimeoutModal";
+import MatchErrorModal from "./MatchErrorModal";
 
 interface MatchUIProps {
   onClose: () => void;
@@ -20,12 +21,17 @@ enum UIState {
   StartSession = "StartSession",
   MatchFound = "MatchFound",
   MatchingTimeout = "MatchingTimeout",
+  MatchingError = "MatchingError",
 }
 
 const MatchUI = ({ onClose }: MatchUIProps) => {
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isMatchUIVisible, setIsMatchUIVisible] = useState<boolean>(true);
   const [uiState, setUiState] = useState<UIState>(UIState.StartSession);
+  const [matchmakingError, setMatchmakingError] = useState<string | null>(null);
+  const [isMatching, setIsMatching] = useState(false);
+  const [matchmakingTime, setMatchmakingTime] = useState<number>(0);
+  const [intervalID, setIntervalID] = useState<NodeJS.Timeout | null>(null);
 
   // Initialize socket on component mount
   useEffect(() => {
@@ -44,9 +50,53 @@ const MatchUI = ({ onClose }: MatchUIProps) => {
     };
   }, []);
 
+  useEffect(() => {
+    if (!isConnected) {
+      setIsMatching(false);
+      if (intervalID) {
+        clearInterval(intervalID);
+      }
+    }
+  }, [isConnected, intervalID]);
+
+  const handleMatchingContinue = async (
+    selectedDifficultyKeys: Set<string>,
+    selectedTopicKeys: Set<string>
+  ) => {
+    // Set timer for matchmaking
+    let time = 1;
+    const interval = setInterval(() => {
+      setMatchmakingTime(time);
+      time += 1;
+    }, 1000);
+
+    setIntervalID(interval);
+    // Call the register function
+    await handleRegisterForMatching(selectedDifficultyKeys, selectedTopicKeys);
+    setIsMatching(true);
+  };
+
+  const handleMatchingStop = () => {
+    handleDeregisterForMatching();
+    if (intervalID) {
+      clearInterval(intervalID);
+    }
+    setIsMatching(false);
+  };
+
+  const handleMatchingError = (error: any) => {
+    console.error("Error during matchmaking:", error);
+    if (error === "'User is already registered for matching.") {
+      setMatchmakingError("You are already registered for matching.");
+    } else {
+      setMatchmakingError("An error occurred during matchmaking.");
+    }
+    setUiState(UIState.MatchingError);
+  };
+
   const handleRegisterForMatching = async (
     difficulty: Set<string>,
-    topic: Set<string>,
+    topic: Set<string>
   ) => {
     const userParams = {
       difficulty: Array.from(difficulty).join(","),
@@ -58,9 +108,7 @@ const MatchUI = ({ onClose }: MatchUIProps) => {
       handleMatchFound,
       () => console.log("Registration successful!"), // Handle success
       handleMatchingTimeout,
-      (error) => {
-        console.error("Error during matchmaking:", error); // Handle error
-      },
+      handleMatchingError
     );
   };
 
@@ -92,11 +140,13 @@ const MatchUI = ({ onClose }: MatchUIProps) => {
       {isMatchUIVisible && (
         <>
           <MatchmakingModal
-            handleRegisterForMatching={handleRegisterForMatching}
-            handleDeregisterForMatching={handleDeregisterForMatching}
             isConnected={isConnected}
             onClose={closeModal}
             isOpen={uiState === UIState.StartSession}
+            isMatching={isMatching}
+            matchmakingTime={matchmakingTime}
+            handleStop={handleMatchingStop}
+            handleContinue={handleMatchingContinue}
           />
           <MatchFoundModal
             onClose={closeModal}
@@ -106,6 +156,12 @@ const MatchUI = ({ onClose }: MatchUIProps) => {
             onClose={closeModal}
             isOpen={uiState === UIState.MatchingTimeout}
           />
+          <MatchErrorModal
+            onClose={closeModal}
+            isOpen={uiState === UIState.MatchingError}
+          >
+            {matchmakingError || "An error occurred during matchmaking."}
+          </MatchErrorModal>
         </>
       )}
     </>

--- a/frontend/peerprep/components/matching/MatchmakingModal.tsx
+++ b/frontend/peerprep/components/matching/MatchmakingModal.tsx
@@ -14,25 +14,26 @@ import { useUniqueCategoriesFetcher } from "@/services/questionService";
 import { capitalize } from "@/utils/utils";
 
 interface StartSessionProps {
-  handleDeregisterForMatching: () => void;
-  handleRegisterForMatching: (
-    difficulty: Set<string>,
-    topic: Set<string>,
-  ) => void;
   isConnected: boolean;
   onClose: () => void;
   isOpen: boolean;
+  isMatching: boolean;
+  matchmakingTime: number;
+  handleStop: () => void;
+  handleContinue: (difficulty: Set<string>, topic: Set<string>) => void;
 }
 
 // Maybe pass these in as props? Need to be dynamically retrieved from question-service
 const difficulties = ["Easy", "Medium", "Hard"];
 
 const MatchmakingModal: React.FC<StartSessionProps> = ({
-  handleDeregisterForMatching,
-  handleRegisterForMatching,
   isConnected,
   onClose,
   isOpen,
+  isMatching,
+  matchmakingTime,
+  handleStop,
+  handleContinue,
 }) => {
   const { categoryData, categoryError, categoryLoading } =
     useUniqueCategoriesFetcher();
@@ -45,21 +46,9 @@ const MatchmakingModal: React.FC<StartSessionProps> = ({
 
   //TODO: Load difficulty and topic from the question-service
   const [selectedDifficultyKeys, setSelectedDifficultyKeys] = useState(
-    new Set<string>(),
+    new Set<string>()
   );
   const [selectedTopicKeys, setSelectedTopicKeys] = useState(new Set<string>());
-  const [isMatching, setIsMatching] = useState(false);
-  const [matchmakingTime, setMatchmakingTime] = useState<number>(0);
-  const [intervalID, setIntervalID] = useState<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    if (!isConnected) {
-      setIsMatching(false);
-      if (intervalID) {
-        clearInterval(intervalID);
-      }
-    }
-  }, [isConnected, intervalID]);
 
   const handleDifficultyChange = (keys: any) => {
     if (new Set(keys).size >= 1) {
@@ -73,28 +62,6 @@ const MatchmakingModal: React.FC<StartSessionProps> = ({
       // Stops empty selection
       setSelectedTopicKeys(new Set(keys));
     }
-  };
-
-  const handleContinue = async () => {
-    // Set timer for matchmaking
-    let time = 0;
-    const interval = setInterval(() => {
-      setMatchmakingTime(time);
-      time += 1;
-    }, 1000);
-
-    setIntervalID(interval);
-    // Call the register function
-    await handleRegisterForMatching(selectedDifficultyKeys, selectedTopicKeys);
-    setIsMatching(true);
-  };
-
-  const handleStop = () => {
-    handleDeregisterForMatching();
-    if (intervalID) {
-      clearInterval(intervalID);
-    }
-    setIsMatching(false);
   };
 
   return (
@@ -183,7 +150,9 @@ const MatchmakingModal: React.FC<StartSessionProps> = ({
               className="flex-1 mx-1"
               radius="sm"
               size="lg"
-              onClick={() => handleContinue()}
+              onClick={() =>
+                handleContinue(selectedDifficultyKeys, selectedTopicKeys)
+              }
               isDisabled={
                 isMatching ||
                 !isConnected ||

--- a/frontend/peerprep/services/matchingSocketService.ts
+++ b/frontend/peerprep/services/matchingSocketService.ts
@@ -41,7 +41,7 @@ const createSocketConnection = (token: string): Socket => {
 
 // Function to initialize and connect the socket
 export const initializeSocket = () => {
-  const token = localStorage.getItem("jwt") || "invalid"; // TODO: Replace with real JWT token
+  const token = localStorage.getItem("accessToken") || "invalid"; // TODO: Replace with real JWT token
 
   socket = createSocketConnection(token);
   socket.connect();

--- a/matching-service/src/model/matching-model.ts
+++ b/matching-service/src/model/matching-model.ts
@@ -56,6 +56,11 @@ export async function getSocketIdForUser(userId: string): Promise<string> {
     return user.socketId;
 }
 
+export async function isUserInSearchPool(userId: string): Promise<boolean> {
+    const redisClient = getRedisClient();
+    return await redisClient.sIsMember('searchPool', userId);
+}
+
 // Add user to the search pool
 export async function addUserToSearchPool(userId: string, socketId: string, criteria: SearchCriteria) {
     const redisClient = getRedisClient();


### PR DESCRIPTION
This PR contains a fix for a case where a user tries to match from multiple windows using the same user. 
- Matching service now checks if user is already in search pool. If it is, the new request is rejected and the socket is disconnected. 
- On the frontend, there is a new model for matchmaking errors. This is displayed when the matching service socket returns an error. 
- Other matching changes that were merged directly into dev branch previously and not documented:
  - Timeout on matching after a certain amount of time (Can be set as an env variable)